### PR TITLE
Handle RETRY / EXPIRED_SESSION Interaction

### DIFF
--- a/payment/src/main/java/net/optile/payment/ui/page/PaymentPagePresenter.java
+++ b/payment/src/main/java/net/optile/payment/ui/page/PaymentPagePresenter.java
@@ -309,6 +309,8 @@ final class PaymentPagePresenter {
                 reloadPaymentSession(result);
                 break;
             case InteractionCode.RETRY:
+                handleOperationInteractionRetry(result);
+                break;
             case InteractionCode.TRY_OTHER_ACCOUNT:
                 continueSessionWithWarning(result);
                 break;
@@ -332,6 +334,18 @@ final class PaymentPagePresenter {
         }
     }
 
+    private void handleOperationInteractionRetry(PaymentResult result) {
+        Interaction interaction = result.getInteraction();
+
+        switch (interaction.getReason()) {
+            case InteractionReason.EXPIRED_SESSION:
+                closeSessionWithCanceledCode(result);
+                break;
+            default:
+                continueSessionWithWarning(result);
+        }
+    }
+    
     private void showInteractionMessage(Interaction interaction) {
         String msg = translateInteraction(interaction, null);
 


### PR DESCRIPTION
Handle the RETRY / EXPIRED_SESSION Interaction, this happens when a preset operation is executed on an expired list.
This will now result in a cancellation of the PaymentSession. 