### PR TITLE
Remove registration id

### DIFF
--- a/payment/src/sharedTest/res/raw/listtemplate.json
+++ b/payment/src/sharedTest/res/raw/listtemplate.json
@@ -5,10 +5,7 @@
     "country": "DE",
     "customer": {
         "number": "42",
-        "email": "john.doe@example.com",
-        "registration": {
-            "id": "5c51c081b55f286f2db9f97au"
-        }
+        "email": "john.doe@example.com"
     },
     "payment": {
         "amount": 1.99,


### PR DESCRIPTION
Remove registration id from the listtemplate.json.
This allows usage of other merchant profiles for automated tests without changing the listtemplate.json file.