### PR TITLE
Pcx 313 smartswitch

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -9,4 +9,4 @@ if [ -d target ]; then
     rm -rf target
 fi
 
-gradle_run_tests
+run_tests gradle

--- a/payment/src/main/java/net/optile/payment/ui/list/NetworkCardViewHolder.java
+++ b/payment/src/main/java/net/optile/payment/ui/list/NetworkCardViewHolder.java
@@ -112,7 +112,7 @@ final class NetworkCardViewHolder extends PaymentCardViewHolder {
         List<PaymentNetwork> networks = card.getPaymentNetworks();
         SmartSwitch smartSwitch = card.getSmartSwitch();
         boolean selected;
-        
+
         for (PaymentNetwork network : networks) {
             selected = !smartSwitch.hasSelected() || smartSwitch.isSelected(network);
             bindLogoView(network.getCode(), network.getLink("logo"), selected);

--- a/payment/src/main/java/net/optile/payment/ui/list/NetworkCardViewHolder.java
+++ b/payment/src/main/java/net/optile/payment/ui/list/NetworkCardViewHolder.java
@@ -24,6 +24,7 @@ import net.optile.payment.core.PaymentInputType;
 import net.optile.payment.ui.model.NetworkCard;
 import net.optile.payment.ui.model.PaymentCard;
 import net.optile.payment.ui.model.PaymentNetwork;
+import net.optile.payment.ui.model.SmartSwitch;
 import net.optile.payment.ui.theme.PaymentTheme;
 import net.optile.payment.ui.widget.FormWidget;
 import net.optile.payment.ui.widget.RegisterWidget;
@@ -93,7 +94,9 @@ final class NetworkCardViewHolder extends PaymentCardViewHolder {
     }
 
     private void bindTitle(NetworkCard card) {
-        List<PaymentNetwork> networks = card.getSmartSelected();
+        SmartSwitch smartSwitch = card.getSmartSwitch();
+        List<PaymentNetwork> networks = smartSwitch.getAllSelected();
+
         if (networks.size() == 0) {
             networks = card.getPaymentNetworks();
         }
@@ -107,10 +110,11 @@ final class NetworkCardViewHolder extends PaymentCardViewHolder {
 
     private void bindLogos(NetworkCard card) {
         List<PaymentNetwork> networks = card.getPaymentNetworks();
-
+        SmartSwitch smartSwitch = card.getSmartSwitch();
         boolean selected;
+        
         for (PaymentNetwork network : networks) {
-            selected = !card.hasSmartSelections() || card.isSmartSelected(network);
+            selected = !smartSwitch.hasSelected() || smartSwitch.isSelected(network);
             bindLogoView(network.getCode(), network.getLink("logo"), selected);
         }
     }

--- a/payment/src/main/java/net/optile/payment/ui/model/AccountCard.java
+++ b/payment/src/main/java/net/optile/payment/ui/model/AccountCard.java
@@ -25,13 +25,11 @@ import net.optile.payment.util.PaymentUtils;
  */
 public final class AccountCard implements PaymentCard {
     private final AccountRegistration account;
-    private final ApplicableNetwork network;
-    private final LanguageFile lang;
+    private final PaymentNetwork network;
 
-    public AccountCard(AccountRegistration account, ApplicableNetwork network, LanguageFile lang) {
+    public AccountCard(AccountRegistration account, PaymentNetwork network) {
         this.account = account;
         this.network = network;
-        this.lang = lang;
     }
 
     /**
@@ -47,7 +45,7 @@ public final class AccountCard implements PaymentCard {
      */
     @Override
     public String getPaymentMethod() {
-        return network.getMethod();
+        return network.getPaymentMethod();
     }
 
     /**
@@ -63,7 +61,7 @@ public final class AccountCard implements PaymentCard {
      */
     @Override
     public LanguageFile getLang() {
-        return lang;
+        return network.getLang();
     }
 
     /**

--- a/payment/src/main/java/net/optile/payment/ui/model/AccountCard.java
+++ b/payment/src/main/java/net/optile/payment/ui/model/AccountCard.java
@@ -16,7 +16,6 @@ import java.util.Map;
 import net.optile.payment.core.LanguageFile;
 import net.optile.payment.model.AccountMask;
 import net.optile.payment.model.AccountRegistration;
-import net.optile.payment.model.ApplicableNetwork;
 import net.optile.payment.model.InputElement;
 import net.optile.payment.util.PaymentUtils;
 

--- a/payment/src/main/java/net/optile/payment/ui/model/PaymentNetwork.java
+++ b/payment/src/main/java/net/optile/payment/ui/model/PaymentNetwork.java
@@ -13,7 +13,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import android.text.TextUtils;
 import net.optile.payment.core.LanguageFile;
 import net.optile.payment.model.ApplicableNetwork;
 import net.optile.payment.model.InputElement;

--- a/payment/src/main/java/net/optile/payment/ui/model/PaymentNetwork.java
+++ b/payment/src/main/java/net/optile/payment/ui/model/PaymentNetwork.java
@@ -26,7 +26,6 @@ public class PaymentNetwork {
 
     private final ApplicableNetwork network;
     private final LanguageFile lang;
-    private String smartSelectionRegex;
 
     public PaymentNetwork(ApplicableNetwork network, LanguageFile lang) {
         this.network = network;
@@ -79,10 +78,6 @@ public class PaymentNetwork {
         return lang;
     }
 
-    public void setSmartSelectionRegex(String regex) {
-        this.smartSelectionRegex = regex;
-    }
-
     public boolean compare(PaymentNetwork network) {
         List<InputElement> srcItems = getInputElements();
         List<InputElement> cmpItems = network.getInputElements();
@@ -102,12 +97,5 @@ public class PaymentNetwork {
             }
         }
         return true;
-    }
-
-    boolean validateSmartSelected(String text) {
-        if (text == null || TextUtils.isEmpty(this.smartSelectionRegex)) {
-            return false;
-        }
-        return text.matches(smartSelectionRegex);
     }
 }

--- a/payment/src/main/java/net/optile/payment/ui/model/PresetCard.java
+++ b/payment/src/main/java/net/optile/payment/ui/model/PresetCard.java
@@ -15,7 +15,6 @@ import java.util.Map;
 
 import net.optile.payment.core.LanguageFile;
 import net.optile.payment.model.AccountMask;
-import net.optile.payment.model.ApplicableNetwork;
 import net.optile.payment.model.InputElement;
 import net.optile.payment.model.PresetAccount;
 
@@ -24,13 +23,11 @@ import net.optile.payment.model.PresetAccount;
  */
 public final class PresetCard implements PaymentCard {
     private final PresetAccount account;
-    private final ApplicableNetwork network;
-    private final LanguageFile lang;
+    private final PaymentNetwork network;
 
-    public PresetCard(PresetAccount account, ApplicableNetwork network, LanguageFile lang) {
+    public PresetCard(PresetAccount account, PaymentNetwork network) {
         this.account = account;
         this.network = network;
-        this.lang = lang;
     }
 
     /**
@@ -46,7 +43,7 @@ public final class PresetCard implements PaymentCard {
      */
     @Override
     public String getPaymentMethod() {
-        return network.getMethod();
+        return network.getPaymentMethod();
     }
 
     /**
@@ -62,7 +59,7 @@ public final class PresetCard implements PaymentCard {
      */
     @Override
     public LanguageFile getLang() {
-        return lang;
+        return network.getLang();
     }
 
     /**

--- a/payment/src/main/java/net/optile/payment/ui/model/SmartSwitch.java
+++ b/payment/src/main/java/net/optile/payment/ui/model/SmartSwitch.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2019 optile GmbH
+ * https://www.optile.net
+ *
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more information.
+ */
+
+package net.optile.payment.ui.model;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import android.text.TextUtils;
+
+/**
+ * Class for storing and selecting payment networks based on smart switch logic
+ */
+public final class SmartSwitch {
+
+    private final HashMap<String, String> smartMapping;
+    private final List<PaymentNetwork> networks;
+    private final List<PaymentNetwork> smartSelected;
+    private final List<PaymentNetwork> smartBuffer;
+
+    public SmartSwitch(List<PaymentNetwork> networks) {
+        this.networks = networks;
+        this.smartMapping = new HashMap<>(); 
+        this.smartSelected = new ArrayList<>();
+        this.smartBuffer = new ArrayList<>();
+    }
+
+    public void addSelectionRegex(String code, String regex) {
+        smartMapping.put(code, regex);
+    }
+    
+    /**
+     * Get the list of smart selected PaymentNetworks.
+     *
+     * @return the list of smart selected PaymentNetworks.
+     */
+    public List<PaymentNetwork> getAllSelected() {
+        return smartSelected;
+    }
+
+    /**
+     * Get the first smart selected PaymentNetwork, may return null if none are selected.
+     *
+     * @return the first smart selected PaymentNetwork.
+     */
+    public PaymentNetwork getFirstSelected() {
+        return smartSelected.size() > 0 ? smartSelected.get(0) : null;
+    }
+    
+    /**
+     * Are any PaymentNetworks selected based on smart switch.
+     *
+     * @return true when there are selected payment networks, false otherwise
+     */
+    public boolean hasSelected() {
+        return smartSelected.size() > 0;
+    }
+
+    /**
+     * Check if the PaymentNetwork is smart selected, it is smart selected when the provided number input matches
+     * the regex of this PaymentMethod in the groups settings file. A PaymentMethod is always smart selected when
+     * there is only one PaymentMethod in the NetworkCard.
+     *
+     * @param network to check if smart selection
+     * @return true when smart selected, false otherwise
+     */
+    public boolean isSelected(PaymentNetwork network) {
+        if (networks.size() == 1 && networks.get(0) == network) {
+            return true;
+        }
+        return smartSelected.contains(network);
+    }
+
+    /** 
+     * Validate the PaymentMethods for smart selection given the new text
+     * 
+     * @param text to validate for smart selection
+     * @return true when the smart selection of payment methods has changed, false otherwise 
+     */
+    public boolean validate(String text) {
+        smartBuffer.clear();
+        String regex;
+
+        if (text != null) {
+            for (PaymentNetwork network : networks) {
+                regex = smartMapping.get(network.getCode());
+
+                if (!TextUtils.isEmpty(regex) && text.matches(regex)) {
+                    smartBuffer.add(network);
+                }
+            }
+        }
+        if (!smartSelected.equals(smartBuffer)) {
+            smartSelected.clear();
+            smartSelected.addAll(smartBuffer);
+            return true;
+        }
+        return false;
+    }
+}
+

--- a/payment/src/main/java/net/optile/payment/ui/model/SmartSwitch.java
+++ b/payment/src/main/java/net/optile/payment/ui/model/SmartSwitch.java
@@ -11,6 +11,8 @@ package net.optile.payment.ui.model;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
 
 import android.text.TextUtils;
 
@@ -19,7 +21,7 @@ import android.text.TextUtils;
  */
 public final class SmartSwitch {
 
-    private final HashMap<String, String> smartMapping;
+    private final Map<String, Pattern> smartMapping;
     private final List<PaymentNetwork> networks;
     private final List<PaymentNetwork> smartSelected;
     private final List<PaymentNetwork> smartBuffer;
@@ -32,7 +34,9 @@ public final class SmartSwitch {
     }
 
     public void addSelectionRegex(String code, String regex) {
-        smartMapping.put(code, regex);
+        if (!TextUtils.isEmpty(regex)) {
+            smartMapping.put(code, Pattern.compile(regex));
+        }
     }
 
     /**
@@ -50,7 +54,7 @@ public final class SmartSwitch {
      * @return the first smart selected PaymentNetwork.
      */
     public PaymentNetwork getFirstSelected() {
-        return smartSelected.size() > 0 ? smartSelected.get(0) : null;
+        return smartSelected.isEmpty() ? null : smartSelected.get(0);
     }
 
     /**
@@ -85,13 +89,12 @@ public final class SmartSwitch {
      */
     public boolean validate(String text) {
         smartBuffer.clear();
-        String regex;
 
         if (text != null) {
             for (PaymentNetwork network : networks) {
-                regex = smartMapping.get(network.getCode());
+                Pattern pattern = smartMapping.get(network.getCode());
 
-                if (!TextUtils.isEmpty(regex) && text.matches(regex)) {
+                if (pattern != null && pattern.matcher(text).matches()) {
                     smartBuffer.add(network);
                 }
             }

--- a/payment/src/main/java/net/optile/payment/ui/model/SmartSwitch.java
+++ b/payment/src/main/java/net/optile/payment/ui/model/SmartSwitch.java
@@ -26,7 +26,7 @@ public final class SmartSwitch {
 
     public SmartSwitch(List<PaymentNetwork> networks) {
         this.networks = networks;
-        this.smartMapping = new HashMap<>(); 
+        this.smartMapping = new HashMap<>();
         this.smartSelected = new ArrayList<>();
         this.smartBuffer = new ArrayList<>();
     }
@@ -34,7 +34,7 @@ public final class SmartSwitch {
     public void addSelectionRegex(String code, String regex) {
         smartMapping.put(code, regex);
     }
-    
+
     /**
      * Get the list of smart selected PaymentNetworks.
      *
@@ -52,7 +52,7 @@ public final class SmartSwitch {
     public PaymentNetwork getFirstSelected() {
         return smartSelected.size() > 0 ? smartSelected.get(0) : null;
     }
-    
+
     /**
      * Are any PaymentNetworks selected based on smart switch.
      *
@@ -77,11 +77,11 @@ public final class SmartSwitch {
         return smartSelected.contains(network);
     }
 
-    /** 
+    /**
      * Validate the PaymentMethods for smart selection given the new text
-     * 
+     *
      * @param text to validate for smart selection
-     * @return true when the smart selection of payment methods has changed, false otherwise 
+     * @return true when the smart selection of payment methods has changed, false otherwise
      */
     public boolean validate(String text) {
         smartBuffer.clear();

--- a/payment/src/main/java/net/optile/payment/ui/service/PaymentSessionService.java
+++ b/payment/src/main/java/net/optile/payment/ui/service/PaymentSessionService.java
@@ -36,7 +36,6 @@ import net.optile.payment.network.PaymentConnection;
 import net.optile.payment.resource.PaymentGroup;
 import net.optile.payment.resource.ResourceLoader;
 import net.optile.payment.ui.PaymentUI;
-import net.optile.payment.ui.model.SmartSwitch;
 import net.optile.payment.ui.model.AccountCard;
 import net.optile.payment.ui.model.NetworkCard;
 import net.optile.payment.ui.model.PaymentNetwork;
@@ -257,14 +256,14 @@ public final class PaymentSessionService {
             group = groups.get(network.getCode());
 
             if (group == null) {
-                addNetwork2SingleCard(cards,  network);
+                addNetwork2SingleCard(cards, network);
             } else {
                 addNetwork2GroupCard(cards, network, group);
             }
         }
         return new ArrayList<>(cards.values());
     }
-        
+
     private void addNetwork2SingleCard(Map<String, NetworkCard> cards, PaymentNetwork network) throws PaymentException {
         NetworkCard card = new NetworkCard();
         card.addPaymentNetwork(network);


### PR DESCRIPTION
Remove smart switch logic from the NetworkCard and PaymentNetwork classes.
This makes it easier to re-use the PaymentNetwork class for GooglePay activation.