### PR TITLE
Fix layout reference in the example-basic app

### DIFF
--- a/example-basic/src/androidTest/java/net/optile/example/basic/PaymentListTests.java
+++ b/example-basic/src/androidTest/java/net/optile/example/basic/PaymentListTests.java
@@ -56,7 +56,7 @@ public class PaymentListTests {
         onView(withId(R.id.button_action)).perform(click());
 
         intended(hasComponent(PaymentListActivity.class.getName()));
-        onView(withId(R.id.layout_parent)).check(matches(isDisplayed()));
+        onView(withId(R.id.layout_paymentlist)).check(matches(isDisplayed()));
     }
 
     private ListService getListService() throws IOException {


### PR DESCRIPTION
Example basic app was referencing the root layout of the payment list activity with an outdated name.
