### PR TITLE
Change build scripts to work with new gradle support

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -5,4 +5,6 @@ PATH=$PATH:/opt/gocd/build
 
 source /opt/gocd/build/java/buildlib.sh
 
-gradle_build
+configure gradle
+
+source /opt/gocd/build/java/build.sh

--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -5,16 +5,6 @@ PATH=$PATH:/opt/gocd/build
 
 source /opt/gocd/build/java/buildlib.sh
 
-echo "*** Promoting snapshot to release" >&2
-promote_snapshot_to_release_gradle
+configure gradle
 
-if [ ! "x${GIT_REV}" != "x" ] && [ ! "x${VERSION}" != "x" ]; then
-    echo "Error: promote_snapshot_to_release_gradle didn't set \$GIT_REV or \$VERSION" >&2
-    exit 1;
-fi
-
-echo "*** Tagging JIRA" >&2
-jira_tag_issues "${GIT_REV}" "${VERSION}"
-
-git_push_all_changes
-
+source /opt/gocd/build/java/release.sh

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -5,8 +5,6 @@ PATH=$PATH:/opt/gocd/build
 
 source /opt/gocd/build/java/buildlib.sh
 
-if [ -d target ]; then
-    rm -rf target
-fi
+configure gradle
 
-run_tests gradle
+source /opt/gocd/build/java/test.sh


### PR DESCRIPTION
gocd-scripts#105 changes the way we support gradle and this PR changes
.ci so that it works.